### PR TITLE
Switched View to React Fragment, solves redraw issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ const makeCoordinates = feature => {
 const Geojson = props => {
   const overlays = makeOverlays(props.geojson.features);
   return (
-    <View>
+    <React.Fragment key={props.geojson.id || uuid()}>
       {overlays.map(overlay => {
         if (overlay.type === 'point') {
           return (
@@ -111,7 +111,7 @@ const Geojson = props => {
           );
         }
       })}
-    </View>
+    </React.Fragment>
   );
 };
 


### PR DESCRIPTION
Currently, redraw issues occur when adding the Polygons in a `View`, switching to `React.Fragment` which is the preferred way of adding a wrapper element.