### PR TITLE
Forward props to generated map features

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ const Geojson = props => {
         if (overlay.type === 'point') {
           return (
             <MapView.Marker
+              {...props}
               key={overlay.id}
               coordinate={overlay.coordinates}
               pinColor={props.color}
@@ -91,6 +92,7 @@ const Geojson = props => {
         if (overlay.type === 'polygon') {
           return (
             <MapView.Polygon
+              {...props}
               key={overlay.id}
               coordinates={overlay.coordinates}
               holes={overlay.holes}
@@ -103,6 +105,7 @@ const Geojson = props => {
         if (overlay.type === 'polyline') {
           return (
             <MapView.Polyline
+              {...props}
               key={overlay.id}
               coordinates={overlay.coordinates}
               strokeColor={props.strokeColor}


### PR DESCRIPTION
With this code, it would be possible to forward additional props like "zIndex" to the react-native-maps components.